### PR TITLE
caching_sha2_password対応

### DIFF
--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -93,7 +93,8 @@ library
     time >=1.5.0 && <1.12 || ^>=1.12.2 || ^>=1.14,
     tls >=1.7.0 && <1.8 || ^>=1.8.0 || ^>=1.9.0 || ^>=2.0.0 || ^>=2.1.0,
     vector >=0.8 && <0.13 || ^>=0.13.0,
-    word-compat >=0.0 && <0.1
+    word-compat >=0.0 && <0.1,
+    cryptostore
 
   default-language:   Haskell2010
   default-extensions:

--- a/src/Database/MySQL/Protocol/Auth.hs
+++ b/src/Database/MySQL/Protocol/Auth.hs
@@ -144,6 +144,26 @@ putAuth (Auth cap m c n p s) = do
     putByteString p
     putByteString s
     putWord8 0x00
+    putByteString "caching_sha2_password"
+    putWord8 0x00
+
+data RequestPubKey = RequestPubKey deriving (Show, Eq)
+
+putRequestPubKey :: RequestPubKey -> Put
+putRequestPubKey _ = putWord8 0x02
+
+instance Binary RequestPubKey where
+    put = putRequestPubKey
+    get = pure RequestPubKey
+
+data SendEncryptedPassword = SendEncryptedPassword !ByteString deriving (Show, Eq)
+
+putSendEncryptedPassword :: SendEncryptedPassword -> Put
+putSendEncryptedPassword (SendEncryptedPassword p) = putByteString p
+
+instance Binary SendEncryptedPassword where
+    put = putSendEncryptedPassword
+    get = SendEncryptedPassword <$> getByteStringNul
 
 instance Binary Auth where
     get = getAuth
@@ -182,6 +202,7 @@ clientCap =  CLIENT_LONG_PASSWORD
                 .|. CLIENT_MULTI_STATEMENTS
                 .|. CLIENT_MULTI_RESULTS
                 .|. CLIENT_SECURE_CONNECTION
+                .|. CLIENT_PLUGIN_AUTH
 
 clientMaxPacketSize :: Word32
 clientMaxPacketSize = 0x00ffffff :: Word32


### PR DESCRIPTION
mysql 8.4で以下のテストプログラムが動くことを確認

```hs
{-# LANGUAGE OverloadedStrings #-}

module Main where

import Database.MySQL.Base
import qualified System.IO.Streams as Streams

main :: IO ()
main = do
  conn <-
    connect
      defaultConnectInfo {ciUser = "root", ciPassword = "testpass", ciDatabase = "testdb"}
  (defs, is) <- query_ conn "SELECT 1"
  print =<< Streams.toList is
  pure ()
```